### PR TITLE
Apply with force when adding manifest resources

### DIFF
--- a/src/manifests.py
+++ b/src/manifests.py
@@ -145,7 +145,7 @@ class Manifests:
             log.info(
                 f"Adding {obj.kind}/{name}" + (f" to {namespace}" if namespace else "")
             )
-            self.client.apply(obj, name)
+            self.client.apply(obj, name, force=True)
 
     def add_label(self, obj):
         obj["metadata"].setdefault("labels", {})

--- a/tests/integration/test_kubernetes_metrics_server.py
+++ b/tests/integration/test_kubernetes_metrics_server.py
@@ -12,6 +12,7 @@ def update_status_timeout():
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
 async def test_charm_builds_and_deploys(ops_test, metadata, update_status_timeout):
     image = metadata["resources"]["operator-base"]["upstream-source"]
     charm_name = metadata["name"]


### PR DESCRIPTION
The manifests are currently not applied with force. This can cause issues if for some reason the manifests are attempted to be applied again. Using force avoids these potential issues. 